### PR TITLE
Implement future OJP 2.0 features.

### DIFF
--- a/map_ojp_to_ojp.py
+++ b/map_ojp_to_ojp.py
@@ -3,11 +3,15 @@
 import datetime
 
 from ojp import Ojp, Ojprequest, ServiceRequest, OjpfareRequest, FareParamStructure, PassengerCategoryEnumeration, \
-    TypeOfFareClassEnumeration, FarePassengerStructure, TripFareRequestStructure, TripStructure
+    TypeOfFareClassEnumeration, FarePassengerStructure, TripFareRequestStructure, TripStructure, OjptripRequest, \
+    TripResultStructure
 
 from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 from xsdata.models.datatype import XmlDateTime
+
+from ojp.ojptrip_refine_request import OjptripRefineRequest
+from ojp.trip_refine_param_structure import TripRefineParamStructure
 
 config = ParserConfig(
     base_url=None,
@@ -32,6 +36,32 @@ def map_to_individual_ojpfarerequest(trip: TripStructure, now: XmlDateTime) -> O
         trip_fare_request=TripFareRequestStructure(trip=trip)
     )
 
+def map_to_individual_ojptriprefinerequest(trip_result: TripResultStructure, now: XmlDateTime) -> OjptripRefineRequest:
+    return OjptripRefineRequest(
+        request_timestamp=now,
+        refine_params=TripRefineParamStructure(include_intermediate_stops=True),
+        trip_result=trip_result
+    )
+
+# TODO: This will not work until v1.1
+def map_ojp_trip_result_to_ojp_refine_request(ojp: Ojp) -> Ojp:
+    if len(ojp.ojpresponse.service_delivery.ojptrip_delivery) != 1:
+        return None
+
+    now = datetime.datetime.utcnow()
+    now = XmlDateTime.from_datetime(now)
+
+    refinerequest = []
+    for ojptrip_delivery in ojp.ojpresponse.service_delivery.ojptrip_delivery:
+        for trip_result in ojptrip_delivery.trip_result:
+            refinerequest += [map_to_individual_ojptriprefinerequest(trip_result, now)]
+
+    return Ojp(ojprequest=
+               Ojprequest(service_request=
+                   ServiceRequest(requestor_ref="OJP2NOVA",
+                                  request_timestamp=now,
+                                  ojprefinement_request=refinerequest)))
+
 def map_ojp_trip_result_to_ojp_fare_request(ojp: Ojp) -> Ojp:
     if len(ojp.ojpresponse.service_delivery.ojptrip_delivery) != 1:
         return None
@@ -42,7 +72,7 @@ def map_ojp_trip_result_to_ojp_fare_request(ojp: Ojp) -> Ojp:
     farerequest = []
     for ojptrip_delivery in ojp.ojpresponse.service_delivery.ojptrip_delivery:
         for trip_result in ojptrip_delivery.trip_result:
-            farerequest += [map_to_inidividual_ojpfarerequest(trip_result.trip, now)]
+            farerequest += [map_to_individual_ojpfarerequest(trip_result.trip, now)]
 
     return Ojp(ojprequest=
                Ojprequest(service_request=

--- a/network_flow.py
+++ b/network_flow.py
@@ -13,7 +13,8 @@ from configuration import *
 from create_ojp_request import test_create_ojp_trip_request
 from map_nova_to_ojp import test_nova_to_ojp
 from map_ojp_to_nova import test_ojp_fare_request_to_nova_request
-from map_ojp_to_ojp import parse_ojp, map_ojp_trip_result_to_ojp_fare_request
+from map_ojp_to_ojp import parse_ojp, map_ojp_trip_result_to_ojp_fare_request, \
+    map_ojp_trip_result_to_ojp_refine_request
 from nova import PreisAuskunftServicePortTypeSoapv14ErstellePreisAuskunft
 from ojp import Ojp
 
@@ -93,6 +94,16 @@ if __name__ == '__main__':
     ojp_trip_result = parse_ojp(r)
     ojp_trip_result_xml = serializer.render(ojp_trip_result, ns_map=ns_map)
     open('ojp_trip_reply.xml', 'w').write(ojp_trip_result_xml)
+
+    # TODO: This would only work in OJP v1.1
+    # ojp_refine_request = map_ojp_trip_result_to_ojp_refine_request(ojp_trip_result)
+    # ojp_refine_request_xml = serializer.render(ojp_refine_request, ns_map=ns_map)
+    # open('ojp_trip_refine_request.xml', 'w').write(ojp_refine_request_xml)
+    # r = call_ojp_2000(ojp_refine_request_xml)
+
+    ojp_trip_result = parse_ojp(r)
+    ojp_trip_result_xml = serializer.render(ojp_trip_result, ns_map=ns_map)
+    open('ojp_trip_refine_reply.xml', 'w').write(ojp_trip_result_xml)
 
     ojp_fare_request = map_ojp_trip_result_to_ojp_fare_request(ojp_trip_result)
     ojp_fare_request_xml = serializer.render(ojp_fare_request, ns_map=ns_map)


### PR DESCRIPTION
If upstream would ever support v1.1 features like trip refinement, we can upgrade incoming requests.