### PR TITLE
Set environment variables to disable file logging when using docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ COPY ojp2/ ojp2/
 COPY nova/ nova/
 COPY api/ api/
 EXPOSE 8000
+ENV LOG_LEVEL=INFO
+ENV XML_LOG_ENABLED=false
+ENV LOG_FILE_HANDLER_ENABLED=false
 CMD ["fastapi","run","/app/server.py","--port", "8000"]


### PR DESCRIPTION
Fix that prevents an error where the application cannot be started up in docker because it is trying to write to a log file (where the directory may not exist or may have no permissions).