### PR TITLE
Feature/skiplus 1263 configure ojp base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ __pycache__/
 /generated/nova_stammdaten.xml
 /generated/*.csv
 /generated/nova_p_r*.*
-
 generated/out.py
+
+# Mac specific files
+.DS_Store

--- a/configuration.py
+++ b/configuration.py
@@ -24,10 +24,10 @@ NOVA_VERTRIEBS_PUNKT = int(getenv("NOVA_VERTRIEBS_PUNKT","16437"))
 NOVA_VERKAUFS_GERAETE_ID = getenv("NOVA_VERKAUFS_GERAETE_ID","236")
 
 # OJP_Token can be obtained at: https://opentransportdata.swiss/dev-dashboard
-OJP_URL_API = "https://api.opentransportdata.swiss/ojp2020"
+OJP_URL_API = getenv("OJP_BASE_URL","https://api.opentransportdata.swiss/ojp2020")
 OJP_TOKEN = getenv("OJP_TOKEN")
 
-OJP_2_URL_API = "https://api.opentransportdata.swiss/ojp20"
+OJP_2_URL_API = getenv("OJP2_BASE_URL","https://api.opentransportdata.swiss/ojp20")
 OJP_2_TOKEN = getenv("OJP2_TOKEN")
 
 OJP_FARE_TOKEN=""


### PR DESCRIPTION
Small PR introducing env variables for the OJP base url.

This will allow to configure and run ojpfare against INT ojp in an integration environment. Default values for the OJP base url are the same values as before (pointing to prod OJP) - thus, on changes required on PROD.