### PR TITLE
fixing_sloid_generation

### DIFF
--- a/input/input_sloid_test.xml
+++ b/input/input_sloid_test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OJP xmlns="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" version="2.0">
+  <OJPRequest>
+    <siri:ServiceRequest>
+      <siri:ServiceRequestContext>
+        <siri:Language>de</siri:Language>
+      </siri:ServiceRequestContext>
+      <siri:RequestTimestamp>2026-06-10T12:13:10.086Z</siri:RequestTimestamp>
+      <siri:RequestorRef>OJP_DemoApp_Beta_OJP2.0</siri:RequestorRef>
+      <OJPTripRequest>
+        <siri:RequestTimestamp>2026-06-10T12:13:10.086Z</siri:RequestTimestamp>
+        <Origin>
+          <PlaceRef>
+            <StopPlaceRef>ch:1:sloid:72345</StopPlaceRef>
+            <Name>
+              <Text>n/a</Text>
+            </Name>
+          </PlaceRef>
+        </Origin>
+        <Destination>
+          <PlaceRef>
+            <StopPlaceRef>ch:1:sloid:3016</StopPlaceRef>
+            <Name>
+              <Text>n/a</Text>
+            </Name>
+          </PlaceRef>
+        </Destination>
+        <Params>
+          <NumberOfResults>5</NumberOfResults>
+          <UseRealtimeData>explanatory</UseRealtimeData>
+          <IncludeAllRestrictedLines>true</IncludeAllRestrictedLines>
+          <IncludeTrackSections>false</IncludeTrackSections>
+          <IncludeLegProjection>false</IncludeLegProjection>
+          <IncludeIntermediateStops>true</IncludeIntermediateStops>
+        </Params>
+      </OJPTripRequest>
+    </siri:ServiceRequest>
+  </OJPRequest>
+</OJP>

--- a/input/input_sloid_test_with_didok_request.xml
+++ b/input/input_sloid_test_with_didok_request.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OJP xmlns="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" version="2.0">
+  <OJPRequest>
+    <siri:ServiceRequest>
+      <siri:ServiceRequestContext>
+        <siri:Language>de</siri:Language>
+      </siri:ServiceRequestContext>
+      <siri:RequestTimestamp>2026-06-10T12:13:10.086Z</siri:RequestTimestamp>
+      <siri:RequestorRef>OJP_DemoApp_Beta_OJP2.0</siri:RequestorRef>
+      <OJPTripRequest>
+        <siri:RequestTimestamp>2026-06-10T12:13:10.086Z</siri:RequestTimestamp>
+        <Origin>
+          <PlaceRef>
+            <StopPlaceRef>8572345</StopPlaceRef>
+            <Name>
+              <Text>n/a</Text>
+            </Name>
+          </PlaceRef>
+        </Origin>
+        <Destination>
+          <PlaceRef>
+            <StopPlaceRef>8503016</StopPlaceRef>
+            <Name>
+              <Text>n/a</Text>
+            </Name>
+          </PlaceRef>
+        </Destination>
+        <Params>
+          <NumberOfResults>5</NumberOfResults>
+          <UseRealtimeData>explanatory</UseRealtimeData>
+          <IncludeAllRestrictedLines>true</IncludeAllRestrictedLines>
+          <IncludeTrackSections>false</IncludeTrackSections>
+          <IncludeLegProjection>false</IncludeLegProjection>
+          <IncludeIntermediateStops>true</IncludeIntermediateStops>
+        </Params>
+      </OJPTripRequest>
+    </siri:ServiceRequest>
+  </OJPRequest>
+</OJP>

--- a/support.py
+++ b/support.py
@@ -72,6 +72,10 @@ def sloid2didok(sloid:str)->int:
         "8014487": "8503462",
     }
 
+    # if _gen is in the sloid, we remove _gen and everything to the right
+    if '_gen' in sloid:
+        sloid= sloid.split("_gen", 1)[0]
+        #this gives us a clean sloid of the stop for further processing
     try:
         # sloids are not integer, but didok are. So we first try to convert to id. If this works, we assume, it is a didok code
         didok=int(sloid)
@@ -79,17 +83,18 @@ def sloid2didok(sloid:str)->int:
         return didok
     except:
         #remove left part of sloid
-        sloid=sloid.replace('ch:1:sloid:','')
-        #remove the right part of sloid, if it exist
+        sloid = sloid.replace('ch:1:sloid:','')
+        #remove the right part of sloid, if it exists
+        tmp=sloid
         if ':' in sloid:
             tmp = sloid[:sloid.find(':')]
         # if bigger than 100000 -> no add. This is used for the 11-14 prefixes that are used for sloid that are used for local public transport
         # outside Switzerland
         if int(tmp)>100000:
             return int(tmp)
-        tmp= 8500000+int(tmp)
-        tmp=my_dict.get(str(tmp),str(tmp)) # replaces if it is in the table or gets the value back
-        return tmp
+        tmp = 8500000+int(tmp)
+        tmp = my_dict.get(str(tmp),str(tmp)) # replaces if it is in the table or gets the value back
+        return int(tmp)
 
 
 # raising an error and sending it back. Does not add values from err_str

--- a/test_configuration.py
+++ b/test_configuration.py
@@ -1,35 +1,8 @@
 READFILE = []
 
-
-READFILE.append("input/input_Bern_Belp.xml")
-
-READFILE.append("input/input_oev_shart_plus_long.xml")
-READFILE.append("input/input_Zuerich_Chur.xml")
-READFILE.append("input/input_Visp_SaaS_Fee_problem_1_preis.xml") #1. class price problematic
-READFILE.append("input/input_strange_price.xml")
-READFILE.append("input/input_Zuerich_Bern.xml")
-READFILE.append("input/input_Basel_Sargans.xml")
-READFILE.append("input/input_Bern_Interlaken_Ost.xml")
-READFILE.append("input/input_Bern_Interlaken_Gymnasium.xml")
-READFILE.append("input/input_Bern_Guisanplatz_Interlaken_Gymnasium.xml")
-READFILE.append("input/input_local.xml")
-READFILE.append("input/input_oev_shart_plus_long.xml")
-READFILE.append("input/input_bus_postauto.xml")
-READFILE.append("input/input_sharing_intercity.xml")
-READFILE.append("input/input_problematic_case_vasile.xml")
-READFILE.append("input/input_Europaplatz.xml")
-READFILE.append("input/input_Bodensee_1.xml")
-READFILE.append("input/input_test_europaplatz.xml")
+READFILE.append("input/input_sloid_test_with_didok_request.xml")
 
 
-# Working OJP 2.0 example
-#READFILE.append("input/input_ojp_1_test.xml")
-READFILE.append("input/input_ojp_2_test.xml")
-READFILE.append("input/input_problematic_Europaplatz_ojp1.xml")
-READFILE.append("input/input_problematic_Europaplatz_ojp2.xml")
-READFILE.append("input/input_Bodensee_2.xml")
-READFILE.append("input/input_problem_footpath.xml")
-READFILE.append("input/input_problematic_Europaplatz_4.xml")
 
 '''
 ----------------------------------------------------------------
@@ -65,6 +38,8 @@ READFILE.append("input/input_problematic_Europaplatz_ojp2.xml")
 READFILE.append("input/input_Bodensee_2.xml")
 READFILE.append("input/input_problem_footpath.xml")
 READFILE.append("input/input_problematic_Europaplatz_4.xml")
+READFILE.append("input/input_sloid_test.xml")
+READFILE.append("input/input_sloid_test_with_didok_request.xml")
 
 
 


### PR DESCRIPTION
for update on 2026-06-11
* fixes the problem with not initalising tmp
* fixes the problem with the _gen pseudo-sloid
* adds two new test files that need to be added to the test_configuration.json in 1.4

Based on error report from Vasile: 
Here is the example that crashes the ojp-nova at the moment
[https://opentdatach.github.io/ojp-demo-app/search?from=ch:1:sloid:72345&to=ch:1:sloid:3016&stage=v2-int](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fopentdatach.github.io%2Fojp-demo-app%2Fsearch%3Ffrom%3Dch%3A1%3Asloid%3A72345%26to%3Dch%3A1%3Asloid%3A3016%26stage%3Dv2-int&data=05%7C02%7Cmatthias.guenter%40sbb.ch%7C6d7d19ef26bc4e772f8708dec63a3a28%7C2cda5d11f0ac46b3967daf1b2e1bd01a%7C0%7C0%7C639166150556202074%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=lnXN2ZafdEQP4FSV4Sq9XGX%2BUCv70r484Idov0PdvQE%3D&reserved=0)

Its crashing in the sloid2didkok helper
[https://github.com/openTdataCH/ojp-nova/blob/master/support.py#L81-L92](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FopenTdataCH%2Fojp-nova%2Fblob%2Fmaster%2Fsupport.py%23L81-L92&data=05%7C02%7Cmatthias.guenter%40sbb.ch%7C6d7d19ef26bc4e772f8708dec63a3a28%7C2cda5d11f0ac46b3967daf1b2e1bd01a%7C0%7C0%7C639166150556236236%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=DfqghAkohNf%2Bwe0lF3Mp9870Xq0DgCdbIJCG08bip8A%3D&reserved=0)

Issue1
sloids like "ch:1:sloid:293" are not handled, tmp var is not created
 
<img width="540" height="196" alt="image" src="https://github.com/user-attachments/assets/02303ab8-5211-416c-b1f1-b0c579b5e8ab" />


Issue 2
TR returns a funny (but valid?) sloid "ch:1:sloid:3000_gen:ch:1:sloid:3000:501:33_pf:33AB"
 
<img width="544" height="208" alt="image" src="https://github.com/user-attachments/assets/f62b1e1a-cef6-4bbf-8bb5-461059792bc9" />


and "3000_gen" parse crash in int(tmp) line

Here is a patch but maybe you want to make the parser more robust, i.e. to strip all non-digits and keep the number only after spliting by : ?
[https://gist.github.com/vasile/56c039addfb6bb053d19a5e60afde124](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgist.github.com%2Fvasile%2F56c039addfb6bb053d19a5e60afde124&data=05%7C02%7Cmatthias.guenter%40sbb.ch%7C6d7d19ef26bc4e772f8708dec63a3a28%7C2cda5d11f0ac46b3967daf1b2e1bd01a%7C0%7C0%7C639166150556257061%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=UgFOnM2m3Qpzv%2FjrB%2BY1A93d6PSKtukvW47EDfdiWhY%3D&reserved=0)

If you want I can make a PR. 

Also, let me know the tyk/server where I can already test ojp-nova openshift version with OJP Demo App.